### PR TITLE
fix: isPictureInPictureActive needs to be updated when user exits PIP

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,15 @@ interface EnterPictureInPictureEventInit extends EventInit {
   pictureInPictureWindow: PictureInPictureWindow
 }
 
+interface LeavePictureInPictureEventInit extends EventInit {
+  pictureInPictureWindow: PictureInPictureWindow
+}
+
 export interface EnterPictureInPictureEvent extends Event {
+  readonly pictureInPictureWindow: PictureInPictureWindow
+}
+
+export interface LeavePictureInPictureEvent extends Event {
   readonly pictureInPictureWindow: PictureInPictureWindow
 }
 

--- a/src/use-picture-in-picture.ts
+++ b/src/use-picture-in-picture.ts
@@ -9,6 +9,7 @@ import {
   usePictureInPictureOptions,
   usePictureInPictureReturnType,
   VideoRefType,
+  EnterPictureInPictureEvent,
 } from './types'
 
 export default function usePictureInPicture(
@@ -57,47 +58,48 @@ export default function usePictureInPicture(
         !isPictureInPictureDisabled(videoRef.current)
     )
 
-    if (
-      onEnterPictureInPicture &&
-      typeof onEnterPictureInPicture === 'function'
-    ) {
-      videoRef.current.addEventListener(
-        'enterpictureinpicture',
-        onEnterPictureInPicture
-      )
+    function _onEnterPictureInPicture(e: EnterPictureInPictureEvent) {
+      if (
+        onEnterPictureInPicture &&
+        typeof onEnterPictureInPicture === 'function'
+      ) {
+        // @ts-ignore
+        onEnterPictureInPicture(e)
+      }
+      togglePictureInPicture(true)
     }
-    if (
-      onLeavePictureInPicture &&
-      typeof onLeavePictureInPicture === 'function'
-    ) {
-      videoRef.current.addEventListener(
-        'leavepictureinpicture',
-        onLeavePictureInPicture
-      )
+    function _onLeavePictureInPicture(e: Event) {
+      if (
+        onLeavePictureInPicture &&
+        typeof onLeavePictureInPicture === 'function'
+      ) {
+        // @ts-ignore
+        onLeavePictureInPicture(e)
+      }
+      togglePictureInPicture(false)
     }
+
+    videoRef.current.addEventListener(
+      'enterpictureinpicture',
+      _onEnterPictureInPicture
+    )
+    videoRef.current.addEventListener(
+      'leavepictureinpicture',
+      _onLeavePictureInPicture
+    )
 
     return () => {
       if (videoRef.current === null) {
         return
       }
-      if (
-        onEnterPictureInPicture &&
-        typeof onEnterPictureInPicture === 'function'
-      ) {
-        videoRef.current.removeEventListener(
-          'enterpictureinpicture',
-          onEnterPictureInPicture
-        )
-      }
-      if (
-        onLeavePictureInPicture &&
-        typeof onLeavePictureInPicture === 'function'
-      ) {
-        videoRef.current.removeEventListener(
-          'leavepictureinpicture',
-          onLeavePictureInPicture
-        )
-      }
+      videoRef.current.removeEventListener(
+        'enterpictureinpicture',
+        _onEnterPictureInPicture
+      )
+      videoRef.current.removeEventListener(
+        'leavepictureinpicture',
+        _onLeavePictureInPicture
+      )
     }
   }, [])
 
@@ -138,9 +140,7 @@ function checkAvailability(video: ExtendedHTMLVideoElement | null) {
     )
   }
   if (video && isWebkitPictureInPictureSupported(video)) {
-    console.warn(
-      'Your browser supports a none-standard Picture in picture API.'
-    )
+    console.warn('Your browser supports a non-standard Picture in picture API.')
   }
 }
 


### PR DESCRIPTION
This is when the user clicks the restore button using browser control:

<img width="405" alt="Screenshot 2024-05-01 at 11 08 05 AM" src="https://github.com/DawChihLiou/react-use-pip/assets/137957101/d5a42c2e-8b15-4cc2-933e-12b1de0c57e1">

`isPictureInPictureActive` wasn't being updated in that case since only the toggle method from the hook return was updating it.
